### PR TITLE
Configurable docker image for Rss2Email

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ RUN cargo build --release $compile_flag
 FROM scratch
 WORKDIR /opt/rss2email
 COPY --from=builder /opt/rss2email/target/release/rss2email .
-COPY ./.env ./.env
-COPY ./feeds.txt ./feeds.txt
+# Place configuring files in a dedicated folder
+COPY ./.env ./config/.env
+COPY ./feeds.txt ./config/feeds.txt
 
-CMD ["./rss2email"]
+# Start the container from this dedicated folder
+WORKDIR /opt/rss2email/config
+CMD ["/opt/rss2email/rss2email"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.64-alpine as builder
+FROM docker.io/rust:1.64-alpine as builder
 
 # Read https://github.com/AntoniosBarotsis/Rss2Email/wiki#deploying
 #


### PR DESCRIPTION
This PR offers an alternative approach to #7. 

While it is still interesting to read configuration from env vars, as suggested by the [12 Factors approach](https://12factor.net/config), we can easily move all files to a dedicated directory and rebind it when running the container.
This is what this PR offers.

Assuming that the image is named `rss2email`:
 - `docker run rss2email` runs the process with the default config, shipped in the image
 - `docker run -v path/to/config:/opt/rss2email/config rss2email` runs the process with the config files located in _path/to/config_.

Bonus, you can also avoid shipping your credentials from the .env file in your Docker image.