### PR TITLE
Added local `mail` command support

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 tab_spaces = 2
+edition ="2021"

--- a/src/email/email_provider.rs
+++ b/src/email/email_provider.rs
@@ -1,30 +1,37 @@
+use super::mail_cmd::MailCommand;
 use super::sendgrid::SendGrid;
 use enum_dispatch::enum_dispatch;
-use log::warn;
 
 /// An email provider abstraction to allow for multiple backends.
 #[enum_dispatch]
 pub trait EmailProvider {
   /// Sends an email to and from the specified address.
-  fn send_email(&self, address: &str, api_key: &str, contents: &str);
+  fn send_email(&self, address: &str, contents: &str);
 }
 
 /// An enum containing all Email Provider implementations.
 #[enum_dispatch(EmailProvider)]
 enum EmailProviders {
   SendGrid(SendGrid),
+  MailCommand(MailCommand),
 }
 
-impl From<String> for EmailProviders {
-  fn from(input: String) -> Self {
-    // Note that the input is trimmed and converted
-    // to upper case for the sake of consistency
-    match input.trim().to_uppercase().as_str() {
-      "SENDGRID" => Self::SendGrid(SendGrid::new()),
-      e => {
-        warn!("Invalid Email provider: {}, defaulting to SendGrid.", e);
-        Self::SendGrid(SendGrid::new())
+impl TryFrom<String> for EmailProviders {
+  type Error = String;
+
+  fn try_from(value: String) -> Result<Self, Self::Error> {
+    let client = value.trim().to_uppercase();
+    match client.as_str() {
+      "SENDGRID" => {
+        let api_key = std::env::var("API_KEY");
+        if let Ok(the_key) = api_key {
+          Ok(Self::SendGrid(SendGrid::new(the_key)))
+        } else {
+          Err("Cannot use SendGrid without API_KEY".to_owned())
+        }
       }
+      "MAIL_COMMAND" => Ok(Self::MailCommand(MailCommand {})),
+      _ => Err("Requested client not found".to_owned()),
     }
   }
 }
@@ -32,10 +39,32 @@ impl From<String> for EmailProviders {
 /// Abstracts away the email backend.
 ///
 /// By default, this will return the `SendGrid` implementation.
-pub fn get_email_provider() -> impl EmailProvider {
+pub fn get_email_provider() -> Result<impl EmailProvider, String> {
   let env_var = std::env::var("EMAIL")
     .ok()
     .unwrap_or_else(|| "SENDGRID".to_owned());
 
-  EmailProviders::from(env_var)
+  EmailProviders::try_from(env_var)
+}
+
+#[cfg(test)]
+mod tests {
+
+  use super::EmailProviders;
+  use std::env;
+
+  #[test]
+  fn load_sendgrid() {
+    env::remove_var("API_KEY");
+    assert!(
+      EmailProviders::try_from("SENDGRID".to_owned()).is_err(),
+      "Mandatory API_KEY should cause an Err()"
+    );
+    env::set_var("API_KEY", "ASD");
+    assert!(
+      EmailProviders::try_from("SENDGRID".to_owned()).is_ok(),
+      "Failed to load proper Email Provider SendGrid"
+    );
+    env::remove_var("API_KEY");
+  }
 }

--- a/src/email/mail_cmd.rs
+++ b/src/email/mail_cmd.rs
@@ -12,21 +12,19 @@ impl EmailProvider for MailCommand {
   }
 }
 
-const TEMPORARY_FILE_NAME : &str = "/tmp/rss2-email.txt";
-
+const TEMPORARY_FILE_NAME: &str = "/tmp/rss2-email.txt";
 
 #[cfg(not(target_os = "windows"))]
 fn send_email(address: &str, contents: &str) {
-  use log::{info,warn};
+  use log::{info, warn};
   use std::{fs::File, io::Write, process::Command};
 
-  let mut file =
-    File::create(TEMPORARY_FILE_NAME).expect("Can't create temporary file /tmp/rss2-email.txt");
+  let mut file = File::create(TEMPORARY_FILE_NAME).expect("Can't create temporary file");
   file
     .write_all(contents.as_bytes())
-    .expect("Failed to write temporary email");
+    .expect("Failed to write temporary email file");
 
-  let mail_command = format!("mail -s \"Rss2Email\" \"{address}\" < /tmp/rss2-email.txt");
+  let mail_command = format!("mail -s \"Rss2Email\" \"{address}\" < {TEMPORARY_FILE_NAME}");
 
   let mut mail_sender = Command::new("sh")
     .args(["-c", &mail_command])
@@ -36,10 +34,9 @@ fn send_email(address: &str, contents: &str) {
   let exit_status = mail_sender.wait().expect("Mail command failed");
   info!("Mail command finished with status {exit_status}");
 
-  if let Err(x) = std::fs::remove_file(TEMPORARY_FILE_NAME){
+  if let Err(x) = std::fs::remove_file(TEMPORARY_FILE_NAME) {
     warn!("Unable to delete {TEMPORARY_FILE_NAME} for error: {x}");
-  } 
-
+  }
 }
 
 #[cfg(target_os = "windows")]

--- a/src/email/mail_cmd.rs
+++ b/src/email/mail_cmd.rs
@@ -7,5 +7,35 @@ use super::email_provider::EmailProvider;
 pub struct MailCommand {}
 
 impl EmailProvider for MailCommand {
-  fn send_email(&self, address: &str, contents: &str) {}
+  fn send_email(&self, address: &str, contents: &str) {
+    send_email(address, contents);
+  }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn send_email(address: &str, contents: &str) {
+  use log::info;
+  use std::{fs::File, io::Write, process::Command};
+
+  let mut file =
+    File::create("/tmp/rss2-email.txt").expect("Can't create temporary file /tmp/rss2-email.txt");
+  file
+    .write_all(contents.as_bytes())
+    .expect("Failed to write temporary email");
+
+  let mail_command = format!("sendmail -s \"Rss2Email\" \"{address}\" < /tmp/rss2-email.txt");
+
+  let mut mail_sender = Command::new("sh")
+    .args(["-c", &mail_command])
+    .spawn()
+    .expect("Could not start mail command, is it installed and configured?");
+
+  let exit_status = mail_sender.wait().expect("Mail command failed");
+  info!("Mail command finished with status {exit_status}");
+}
+
+#[cfg(target_os = "windows")]
+fn send_email(address: &str, contents: &str) {
+  use log::error;
+  error!("No known mail/sendmail/smtp command for Windows OS");
 }

--- a/src/email/mail_cmd.rs
+++ b/src/email/mail_cmd.rs
@@ -1,9 +1,7 @@
-/**
- * Implementation for default "mail" command in linux
- */
 use super::email_provider::EmailProvider;
 
 #[derive(Default)]
+/// Implementation for default `mail` command in linux.
 pub struct MailCommand {}
 
 impl EmailProvider for MailCommand {
@@ -12,12 +10,12 @@ impl EmailProvider for MailCommand {
   }
 }
 
-const TEMPORARY_FILE_NAME: &str = "/tmp/rss2-email.txt";
-
 #[cfg(not(target_os = "windows"))]
 fn send_email(address: &str, contents: &str) {
   use log::{info, warn};
   use std::{fs::File, io::Write, process::Command};
+
+  const TEMPORARY_FILE_NAME: &str = "/tmp/rss2-email.txt";
 
   let mut file = File::create(TEMPORARY_FILE_NAME).expect("Can't create temporary file");
   file
@@ -40,7 +38,7 @@ fn send_email(address: &str, contents: &str) {
 }
 
 #[cfg(target_os = "windows")]
-fn send_email(address: &str, contents: &str) {
+fn send_email(_address: &str, _contents: &str) {
   use log::error;
   error!("No known mail/sendmail/smtp command for Windows OS");
 }

--- a/src/email/mail_cmd.rs
+++ b/src/email/mail_cmd.rs
@@ -12,18 +12,21 @@ impl EmailProvider for MailCommand {
   }
 }
 
+const TEMPORARY_FILE_NAME : &str = "/tmp/rss2-email.txt";
+
+
 #[cfg(not(target_os = "windows"))]
 fn send_email(address: &str, contents: &str) {
-  use log::info;
+  use log::{info,warn};
   use std::{fs::File, io::Write, process::Command};
 
   let mut file =
-    File::create("/tmp/rss2-email.txt").expect("Can't create temporary file /tmp/rss2-email.txt");
+    File::create(TEMPORARY_FILE_NAME).expect("Can't create temporary file /tmp/rss2-email.txt");
   file
     .write_all(contents.as_bytes())
     .expect("Failed to write temporary email");
 
-  let mail_command = format!("sendmail -s \"Rss2Email\" \"{address}\" < /tmp/rss2-email.txt");
+  let mail_command = format!("mail -s \"Rss2Email\" \"{address}\" < /tmp/rss2-email.txt");
 
   let mut mail_sender = Command::new("sh")
     .args(["-c", &mail_command])
@@ -32,6 +35,11 @@ fn send_email(address: &str, contents: &str) {
 
   let exit_status = mail_sender.wait().expect("Mail command failed");
   info!("Mail command finished with status {exit_status}");
+
+  if let Err(x) = std::fs::remove_file(TEMPORARY_FILE_NAME){
+    warn!("Unable to delete {TEMPORARY_FILE_NAME} for error: {x}");
+  } 
+
 }
 
 #[cfg(target_os = "windows")]

--- a/src/email/mail_cmd.rs
+++ b/src/email/mail_cmd.rs
@@ -1,18 +1,18 @@
-use super::email_provider::EmailProvider;
+use super::{email_provider::EmailProvider, EmailError};
 
 #[derive(Default)]
 /// Implementation for default `mail` command in linux.
 pub struct MailCommand {}
 
 impl EmailProvider for MailCommand {
-  fn send_email(&self, address: &str, contents: &str) {
-    send_email(address, contents);
+  fn send_email(&self, address: &str, contents: &str) -> Result<(), EmailError> {
+    send_email(address, contents)
   }
 }
 
 #[cfg(not(target_os = "windows"))]
-fn send_email(address: &str, contents: &str) {
-  use log::{info, warn};
+fn send_email(address: &str, contents: &str) -> Result<(), EmailError> {
+  use log::info;
   use std::{fs::File, io::Write, process::Command};
 
   const TEMPORARY_FILE_NAME: &str = "/tmp/rss2-email.txt";
@@ -20,25 +20,31 @@ fn send_email(address: &str, contents: &str) {
   let mut file = File::create(TEMPORARY_FILE_NAME).expect("Can't create temporary file");
   file
     .write_all(contents.as_bytes())
-    .expect("Failed to write temporary email file");
+    .map_err(|_e| EmailError::Io("Failed to write temporary email file".to_owned()))?;
 
   let mail_command = format!("mail -s \"Rss2Email\" \"{address}\" < {TEMPORARY_FILE_NAME}");
 
   let mut mail_sender = Command::new("sh")
     .args(["-c", &mail_command])
     .spawn()
-    .expect("Could not start mail command, is it installed and configured?");
+    .map_err(|_e| {
+      EmailError::Other("Could not start mail command, is it installed and configured?".to_owned())
+    })?;
 
   let exit_status = mail_sender.wait().expect("Mail command failed");
   info!("Mail command finished with status {exit_status}");
 
-  if let Err(x) = std::fs::remove_file(TEMPORARY_FILE_NAME) {
-    warn!("Unable to delete {TEMPORARY_FILE_NAME} for error: {x}");
+  match std::fs::remove_file(TEMPORARY_FILE_NAME) {
+    Ok(_) => Ok(()),
+    Err(e) => Err(EmailError::Io(format!(
+      "Unable to delete {TEMPORARY_FILE_NAME} for error: {e}"
+    ))),
   }
 }
 
 #[cfg(target_os = "windows")]
-fn send_email(_address: &str, _contents: &str) {
-  use log::error;
-  error!("No known mail/sendmail/smtp command for Windows OS");
+fn send_email(_address: &str, _contents: &str) -> Result<(), EmailError> {
+  Err(EmailError::Config(
+    "No known mail/sendmail/smtp command for Windows OS".to_owned(),
+  ))
 }

--- a/src/email/mail_cmd.rs
+++ b/src/email/mail_cmd.rs
@@ -1,0 +1,11 @@
+/**
+ * Implementation for default "mail" command in linux
+ */
+use super::email_provider::EmailProvider;
+
+#[derive(Default)]
+pub struct MailCommand {}
+
+impl EmailProvider for MailCommand {
+  fn send_email(&self, address: &str, contents: &str) {}
+}

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,4 +1,5 @@
 #[allow(clippy::module_name_repetitions)]
 #[allow(clippy::use_self)]
 pub mod email_provider;
+pub mod mail_cmd;
 pub mod sendgrid;

--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -1,5 +1,46 @@
+use std::fmt::Display;
+
 #[allow(clippy::module_name_repetitions)]
 #[allow(clippy::use_self)]
 pub mod email_provider;
 pub mod mail_cmd;
 pub mod sendgrid;
+
+/// Holds all environment variables that are required
+/// by any email provider.
+pub struct EnvLoader {
+  pub(crate) api_key: Option<String>,
+}
+
+impl EnvLoader {
+  pub(crate) fn new() -> Self {
+    Self {
+      api_key: std::env::var("API_KEY").ok(),
+    }
+  }
+}
+
+#[allow(dead_code)]
+/// Represents all things that could go wrong
+/// while trying to send an email.
+pub enum EmailError {
+  Config(String),
+  Request(Box<ureq::Error>),
+  Io(String),
+  Other(String),
+}
+
+impl From<ureq::Error> for EmailError {
+  fn from(e: ureq::Error) -> Self {
+    Self::Request(Box::new(e))
+  }
+}
+
+impl Display for EmailError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match &self {
+      Self::Request(e) => write!(f, "{}", e),
+      Self::Config(e) | Self::Io(e) | Self::Other(e) => write!(f, "{}", e),
+    }
+  }
+}

--- a/src/email/sendgrid.rs
+++ b/src/email/sendgrid.rs
@@ -4,23 +4,26 @@ use super::email_provider::EmailProvider;
 
 #[derive(Default)]
 /// `EmailProvider` implementation using [`SendGrid`](https://sendgrid.com/).
-pub struct SendGrid {}
+pub struct SendGrid {
+  api_key: String,
+}
 
 impl SendGrid {
-  pub(crate) fn new() -> Self {
-    Self::default()
+  /// Creates a new [`SendGrid`].
+  pub(crate) const fn new(api_key: String) -> Self {
+    Self { api_key }
   }
 }
 
 impl EmailProvider for SendGrid {
-  fn send_email(&self, address: &str, api_key: &str, contents: &str) {
+  fn send_email(&self, address: &str, contents: &str) {
     let contents = contents.replace('\"', "\\\"");
     let message = format!(
       r#"{{"personalizations": [{{"to": [{{"email": "{address}"}}]}}],"from": {{"email": "{address}"}},"subject": "Rss2Email","content": [{{"type": "text/html", "value": "{contents}"}}]}}"#
     );
 
     let req = ureq::post("https://api.sendgrid.com/v3/mail/send")
-      .set("Authorization", &format!("Bearer {}", &api_key))
+      .set("Authorization", &format!("Bearer {}", &self.api_key))
       .set("Content-Type", "application/json")
       .send_string(&message);
 

--- a/src/email/sendgrid.rs
+++ b/src/email/sendgrid.rs
@@ -1,39 +1,48 @@
-use log::{error, info};
+use log::info;
 
-use super::email_provider::EmailProvider;
+use super::{email_provider::EmailProvider, EmailError, EnvLoader};
 
 #[derive(Default)]
 /// `EmailProvider` implementation using [`SendGrid`](https://sendgrid.com/).
 pub struct SendGrid {
-  api_key: String,
+  api_key: Option<String>,
 }
 
 impl SendGrid {
-  /// Creates a new [`SendGrid`].
-  pub(crate) const fn new(api_key: String) -> Self {
-    Self { api_key }
+  pub(crate) fn new(env_loader: &EnvLoader) -> Self {
+    Self {
+      api_key: env_loader.api_key.clone(),
+    }
   }
 }
 
 impl EmailProvider for SendGrid {
-  fn send_email(&self, address: &str, contents: &str) {
+  fn send_email(&self, address: &str, contents: &str) -> Result<(), EmailError> {
+    let api_key = self
+      .api_key
+      .as_ref()
+      .ok_or_else(|| EmailError::Config("Cannot use SendGrid without API_KEY".to_owned()))?;
+
     let contents = contents.replace('\"', "\\\"");
     let message = format!(
       r#"{{"personalizations": [{{"to": [{{"email": "{address}"}}]}}],"from": {{"email": "{address}"}},"subject": "Rss2Email","content": [{{"type": "text/html", "value": "{contents}"}}]}}"#
     );
 
     let req = ureq::post("https://api.sendgrid.com/v3/mail/send")
-      .set("Authorization", &format!("Bearer {}", &self.api_key))
+      .set("Authorization", &format!("Bearer {}", api_key))
       .set("Content-Type", "application/json")
       .send_string(&message);
 
     match req {
-      Ok(req) => info!(
-        "Email request sent with {} {}",
-        req.status(),
-        req.status_text()
-      ),
-      Err(e) => error!("{}", e),
+      Ok(req) => {
+        info!(
+          "Email request sent with {} {}",
+          req.status(),
+          req.status_text()
+        );
+        Ok(())
+      }
+      Err(e) => Err(e.into()),
     }
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,19 +36,19 @@ fn core_main() -> Result<(), String> {
 
   let html = map_to_html(&blogs);
 
-  if cfg!(debug_assertions) {
+  /*if cfg!(debug_assertions) {
     info!("{}", html);
-  } else {
-    // Only load email related variables if ran on release
-    let address = std::env::var("EMAIL_ADDRESS").expect("EMAIL_ADDRESS must be set.");
+  } else {*/
+  // Only load email related variables if ran on release
+  let address = std::env::var("EMAIL_ADDRESS").expect("EMAIL_ADDRESS must be set.");
 
-    get_email_provider()
-      .and_then(|provider| {
-        provider.send_email(&address, &html);
-        Ok(())
-      })
-      .map_err(|p| error!("Failed to load email service, cause {p}"));
-  }
+  get_email_provider()
+    .and_then(|provider| {
+      provider.send_email(&address, &html);
+      Ok(())
+    })
+    .map_err(|p| error!("Failed to load email service, cause {p}"));
+  //}
 
   Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crate::email::email_provider::{get_email_provider, EmailProvider};
 use dotenv::dotenv;
 use env_logger::Env;
-use log::{error, info, warn};
+use log::{info, warn};
 use rss2email::{download_blogs, map_to_html, time_func};
 
 mod email;
@@ -43,11 +43,7 @@ fn core_main() -> Result<(), String> {
     let address = std::env::var("EMAIL_ADDRESS").expect("EMAIL_ADDRESS must be set.");
 
     get_email_provider()
-      .and_then(|provider| {
-        provider.send_email(&address, &html);
-        Ok(())
-      })
-      .map_err(|p| error!("Failed to load email service, cause {p}"));
+      .map(|provider| provider.send_email(&address, &html))?;
   }
 
   Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use crate::email::email_provider::{get_email_provider, EmailProvider};
 use dotenv::dotenv;
 use env_logger::Env;
-use log::{info, warn};
+use log::{error, info, warn};
 use rss2email::{download_blogs, map_to_html, time_func};
 
 mod email;
@@ -42,7 +42,9 @@ fn core_main() -> Result<(), String> {
     // Only load email related variables if ran on release
     let address = std::env::var("EMAIL_ADDRESS").expect("EMAIL_ADDRESS must be set.");
 
-    get_email_provider().map(|provider| provider.send_email(&address, &html))?;
+    if let Err(e) = get_email_provider().map(|provider| provider.send_email(&address, &html))? {
+      error!("{}", e);
+    };
   }
 
   Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,7 @@ fn core_main() -> Result<(), String> {
     // Only load email related variables if ran on release
     let address = std::env::var("EMAIL_ADDRESS").expect("EMAIL_ADDRESS must be set.");
 
-    get_email_provider()
-      .map(|provider| provider.send_email(&address, &html))?;
+    get_email_provider().map(|provider| provider.send_email(&address, &html))?;
   }
 
   Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,19 +36,19 @@ fn core_main() -> Result<(), String> {
 
   let html = map_to_html(&blogs);
 
-  /*if cfg!(debug_assertions) {
+  if cfg!(debug_assertions) {
     info!("{}", html);
-  } else {*/
-  // Only load email related variables if ran on release
-  let address = std::env::var("EMAIL_ADDRESS").expect("EMAIL_ADDRESS must be set.");
+  } else {
+    // Only load email related variables if ran on release
+    let address = std::env::var("EMAIL_ADDRESS").expect("EMAIL_ADDRESS must be set.");
 
-  get_email_provider()
-    .and_then(|provider| {
-      provider.send_email(&address, &html);
-      Ok(())
-    })
-    .map_err(|p| error!("Failed to load email service, cause {p}"));
-  //}
+    get_email_provider()
+      .and_then(|provider| {
+        provider.send_email(&address, &html);
+        Ok(())
+      })
+      .map_err(|p| error!("Failed to load email service, cause {p}"));
+  }
 
   Ok(())
 }

--- a/test-docker/Dockerfile
+++ b/test-docker/Dockerfile
@@ -1,0 +1,7 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y mailutils \
+    && apt-get clean
+
+COPY rss2email /usr/sbin

--- a/test-docker/build.sh
+++ b/test-docker/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Small script for testing `mail` command version capability
+# Include building of docker image & assembling a test
+
+cd ..
+cargo build --release
+
+cp target/release/rss2email test-docker
+cd test-docker
+
+docker build --rm --tag debian-email:test .
+
+echo " "
+echo "Now to test it... exec following commands:"
+echo " "
+
+echo "docker run -it -e \"EMAIL\"=\"MAIL_COMMAND\" -e \"EMAIL_ADDRESS\"=\"root@localhost\" -e \"FEEDS\"=\"https://blog.rust-lang.org/feed.xml;\" -e \"DAYS\"=\"50\"  debian-email:test "
+echo " "
+echo "rss2email"
+echo " "
+echo "cat /var/mail/mail "


### PR DESCRIPTION
Greetings! 
Found your great project in Hacktoberfest discord: sorry for not contacting you first, I wanted to assemble a working example before proposing.

I'll be glad if you could evaluate this implementation proposal, including the followings:

* Implementation for running a local `mail` command, in case you're running the project where `postfix` or `mailutils` is configured

## Small refactors

* Error/default handling for DAYS env variable.
* `EmailProviders` has a tested path and should permit easier implementation of new backends

## Breaking changes

* Trait function `EmailProvider::send_email()`  no longer requires `api_key` parameter
* `EmailProviders` is now implemented with `TryFrom`, since Provider setup might fail for missing configurations.

## Possible future improvements 

* Having a better parameterized interface as command line, using [clap](https://docs.rs/clap/latest/clap/)
* Fail `MailCommand` creation when there is not an actual `mail` command available
* Support other mail-providers at commandline ( `sendmail`,  `mutt`, etc. )

I'll be glad to hear your feedback, also I understand this might take a path that wasn't intended in the original design.
Thanks you very much for your work.