### PR TITLE
Readme.md, a little restyling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Check out the [build from source](https://github.com/AntoniosBarotsis/Rss2Email/
 
 ## Configuration
 
-**Rss2email** requires some environment variables in order to work, here listed.
+**Rss2email** requires some environment variables in order to work, here listed.  
 These can be provided with any means, including an `.env` file
 
 ### `EMAIL_ADDRESS`
@@ -49,8 +49,8 @@ _eg:_ `"https://blog.rust-lang.org/feed.xml;https://www.linux.org/articles/index
 
 ### `EMAIL` (optional, defaults to `SENDGRID`)
 
-Which provider 
-Defaults to `SENDGRID`, can contain `EMAIL_COMMAND` as an alternative if you have `mail` or `sendmail` installed in your system  
+Which provider to use in order to send the email.  
+Can be set to `EMAIL_COMMAND` as an alternative if you have `mail` or `sendmail` installed in your system  
 
 ### `API_KEY` (optional)
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 [![Build & Tests](https://github.com/AntoniosBarotsis/Rss2Email/actions/workflows/ci.yml/badge.svg)](https://github.com/AntoniosBarotsis/Rss2Email/actions/workflows/ci.yml)
 [![GitHub milestone](https://img.shields.io/github/milestones/progress/AntoniosBarotsis/rss2email/1?color=32ca55&label=Progress%20towards%20v1.0&labelColor=353d46)](https://github.com/users/AntoniosBarotsis/projects/2/views/1?query=is%3Aopen+sort%3Aupdated-desc)
+![Status](https://img.shields.io/badge/status-alpha-orange)
 
-A small program capable of aggregating content from multiple RSS/Atom feeds, and mail them to you in a practical summary email.  
-Keep track of your favourite blogs that don't feature an update newsletter
+A small program capable of aggregating content from multiple RSS/Atom feeds and mailing them to you in a practical summary email.  
+Keep track of your favorite blogs that don't feature an update newsletter
 or similar service.
-
-* **Technology stack**: Rust, Docker, AWS Lambdas
-* **Status**: Alpha
 
 <p align="center">
   <img src="assets/res.jpg" alt="Example">
@@ -20,70 +18,57 @@ You'll need [Rust](https://rust-lang.org/) installed to compile this software.
 
 ## Installation
 
-Current mean of installation is compilation by source code.  
+Currently, you can only build this from source.
 Clone this repository and run:
 
 ```bash
 cargo build --release
 ```
 
-Check out the [build from source](https://github.com/AntoniosBarotsis/Rss2Email/wiki/1.-Home#building-from-source) section from the wiki for more detailed informations.
+Alternatively, you can build a Docker image that you can either run yourself or publish to AWS Lambda.
+
+Check out the [build from [source](https://github.com/AntoniosBarotsis/Rss2Email/wiki/1.-Home#building-from-source)
+section of the wiki for more information.
 
 ## Configuration
 
-**Rss2email** requires some environment variables in order to work, here listed.  
-These can be provided with any means, including an `.env` file
+**Rss2email** requires some environment variables to work. These can be provided either in your shell
+or as entries in a `.env` file.
 
-### `EMAIL_ADDRESS`
+- `EMAIL_ADDRESS`: the mail address you will receive the feed content
+- `DAYS`: this value indicates up to how many days in the past we go to search for entries  
 
-the mail address you will receive the feed content  
+- `FEEDS`: a list of semicolon-separated feed URLs.  
+  _eg:_ `"https://blog.rust-lang.org/feed.xml;https://www.linux.org/articles/index.rss"`
 
-### `DAYS`
+- `EMAIL` (optional, defaults to `SendGrid`):  Which provider to use to send the email.  
+  Can be set to `EMAIL_COMMAND` as an alternative if you have `mail` or `sendmail` installed in your system  
 
-this value indicates up to how many days in the past we go to search for entries  
+- `API_KEY` (optional): Your [SendGrid](https://sendgrid.com/) authentication key.
 
-### `FEEDS`
-
-a list of semicolon-separated feed URLS.  
-_eg:_ `"https://blog.rust-lang.org/feed.xml;https://www.linux.org/articles/index.rss"`
-
-### `EMAIL` (optional, defaults to `SENDGRID`)
-
-Which provider to use in order to send the email.  
-Can be set to `EMAIL_COMMAND` as an alternative if you have `mail` or `sendmail` installed in your system  
-
-### `API_KEY` (optional)
-
-When using [SENDGRID](https://sendgrid.com/) you need one authentication key.
-
-More details are available at wiki section [Running the code](https://github.com/AntoniosBarotsis/Rss2Email/wiki/3.-Running-the-Code)
+More details are available in the [Running the code](https://github.com/AntoniosBarotsis/Rss2Email/wiki/3.-Running-the-Code)
+wiki section.
 
 ## Usage
 
-After setting up the configuration it will be possible to run the program
-
-```bash
-./target/release/Rss2email
-```
-
-Launching the program with cargo, with `dev` flags enabled, no email will be sent.  
-Instead, the email content will be printed to `stdout`
+Running the code in debug mode won't send any emails and will instead output the generated HTML in the console.
 
 ```bash
 cargo run
 ```
 
-## Known Issues
+It is recommended to try this out first and make sure that all your feeds and config variables are correctly set
+up.
 
-### Slowness
+Running the project in release mode will send the emails
 
-Currently, the RSS feeds are downloaded in a sequential, blocking, non-concurrent manner as they are
-only small text files and should thus not take too long (plus this is not supposed to run that often but
-rather something like once a week or so).  
+```bash
+./target/release/Rss2email
+# or
+cargo run --release
+```
 
-If you find yourself either using a *lot* of RSS feeds or really big ones somehow, do give me a heads up
-by submitting an issue and I'll do what I can to make this faster. As of now, there is no reason to do that.
-*That said, I might randomly decide to do this regardless*.
+<!-- ## Known Issues -->
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,32 +3,83 @@
 [![Build & Tests](https://github.com/AntoniosBarotsis/Rss2Email/actions/workflows/ci.yml/badge.svg)](https://github.com/AntoniosBarotsis/Rss2Email/actions/workflows/ci.yml)
 ![GitHub milestone](https://img.shields.io/github/milestones/progress/AntoniosBarotsis/rss2email/1?color=32ca55&label=Progress%20towards%20v1.0&labelColor=353d46)
 
-This project collects blog posts made over the last `n` days from RSS feeds and emails them to you!
+A small program capable of aggregating content from multiple RSS/Atom feeds, and mail them to you in a practical summary email.  
+Keep track of your favourite blogs that don't feature an update newsletter
+or similar service.
+
+* **Technology stack**: Rust, Docker, AWS Lambdas
+* **Status**: Alpha
 
 <p align="center">
   <img src="assets/res.jpg" alt="Example">
 </p>
 
-## Why?
+## Dependencies
 
-I have a few blogs in mind that I do find interesting but they do not provide a newsletter.
+You'll need [Rust](https://rust-lang.org/) installed to compile this software.
 
-There are some RSS readers but I am too lazy to download and use other software exclusively for this,
-I would much rather see a summary of these posts in my mailbox.
+## Installation
 
-## Getting Started
+Current mean of installation is compilation by source code.  
+Clone this repository and run:
 
-This section was getting rather lengthy so I moved it to [the Wiki](https://github.com/AntoniosBarotsis/Rss2Email/wiki/1.-Home)!
+```bash
+cargo build --release
+```
 
-### ⚠ Docker ⚠
+Check out the [build from source](https://github.com/AntoniosBarotsis/Rss2Email/wiki/1.-Home#building-from-source) section from the wiki for more detailed informations.
 
-Please read [this](https://github.com/AntoniosBarotsis/Rss2Email/wiki/1.-Home#-important-) if you are planning on building the docker image.
+## Configuration
 
-## Why is this so Slow?
+**Rss2email** requires some environment variables in order to work, here listed.
+These can be provided with any means, including an `.env` file
 
-Currently, the RSS feeds are downloaded in a sequential, blocking, non-concurrent manner as they are 
+### `EMAIL_ADDRESS`
+
+the mail address you will receive the feed content  
+
+### `DAYS`
+
+this value indicates up to how many days in the past we go to search for entries  
+
+### `FEEDS`
+
+a list of semicolon-separated feed URLS.  
+_eg:_ `"https://blog.rust-lang.org/feed.xml;https://www.linux.org/articles/index.rss"`
+
+### `EMAIL` (optional, defaults to `SENDGRID`)
+
+Which provider 
+Defaults to `SENDGRID`, can contain `EMAIL_COMMAND` as an alternative if you have `mail` or `sendmail` installed in your system  
+
+### `API_KEY` (optional)
+
+When using [SENDGRID](https://sendgrid.com/) you need one authentication key.
+
+More details are available at wiki section [Running the code](https://github.com/AntoniosBarotsis/Rss2Email/wiki/3.-Running-the-Code)
+
+## Usage
+
+After setting up the configuration it will be possible to run the program
+
+```bash
+./target/release/Rss2email
+```
+
+Launching the program with cargo, with `dev` flags enabled, no email will be sent.  
+Instead, the email content will be printed to `stdout`
+
+```bash
+cargo run
+```
+
+## Known Issues
+
+### Slowness
+
+Currently, the RSS feeds are downloaded in a sequential, blocking, non-concurrent manner as they are
 only small text files and should thus not take too long (plus this is not supposed to run that often but
-rather something like once a week or so). 
+rather something like once a week or so).  
 
 If you find yourself either using a *lot* of RSS feeds or really big ones somehow, do give me a heads up
 by submitting an issue and I'll do what I can to make this faster. As of now, there is no reason to do that.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build & Tests](https://github.com/AntoniosBarotsis/Rss2Email/actions/workflows/ci.yml/badge.svg)](https://github.com/AntoniosBarotsis/Rss2Email/actions/workflows/ci.yml)
 [![GitHub milestone](https://img.shields.io/github/milestones/progress/AntoniosBarotsis/rss2email/1?color=32ca55&label=Progress%20towards%20v1.0&labelColor=353d46)](https://github.com/users/AntoniosBarotsis/projects/2/views/1?query=is%3Aopen+sort%3Aupdated-desc)
-![Status](https://img.shields.io/badge/status-alpha-orange)
+![Status](https://img.shields.io/badge/status-alpha-orange?labelColor=353d46)
 
 A small program capable of aggregating content from multiple RSS/Atom feeds and mailing them to you in a practical summary email.  
 Keep track of your favorite blogs that don't feature an update newsletter

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ cargo build --release
 
 Alternatively, you can build a Docker image that you can either run yourself or publish to AWS Lambda.
 
-Check out the [build from [source](https://github.com/AntoniosBarotsis/Rss2Email/wiki/1.-Home#building-from-source)
+Check out the [build from source](https://github.com/AntoniosBarotsis/Rss2Email/wiki/1.-Home#building-from-source)
 section of the wiki for more information.
 
 ## Configuration


### PR DESCRIPTION
This PR contains a proposal of restyle for the documentation part, as per issue #21.
I ended up preparing a practical example instead of exchanging generic guidance.  
As before: its perfectly OK to discard this proposal as not-fitting.

This has been prepared taking consideration of the followings:

* Mature projects tend to touch all essential in README.md and provide link with details, your doc was already ahead on this.
* The `environment variables` sections covers 90% of the software usage, will be the first high step for users.

## Some smaller/trivial matters

I used a `README.md` template that's commonly used.

Link to documentation are clearer when using the destination link title (or usage), like  `[how to build](#)` instead of `follow [this](#) for more details`
